### PR TITLE
Fix: NAPinAnnotation and NAPinAnnotationView retain cycle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
+#### Next
+
+* [#31](https://github.com/neilang/NAMapKit/issues/31) - Fix: `NAPinAnnotation` and `NAPinAnnotationView` retain cycle - [@dblock](https://github.com/dblock).
+
 #### [3.1](https://github.com/neilang/NAMapKit/tree/v3.1) (5/1/2014)
 
-* Replaced tiled map image implementation with [ARTiledImageView](https://github.com/dblock/ARTiledImageView) - [@dblock](github.com/dblock).
-* Extracted [NADotAnnotation](NAMapKit/NADotAnnotation.h) out of [NAAnnotation](NAMapKit/NAAnnotation.h), which is now a pure virtual class - [@dblock](github.com/dblock).
-* Fix: `NADotAnnotation` dots resize proportionally when map zoom level changes - [@dblock](github.com/dblock).
-* Exposed `NAMapView#doubleTapGesture` and `NAMapView#twoFingerTapGesture` - [@orta](github.com/orta).
+* Replaced tiled map image implementation with [ARTiledImageView](https://github.com/dblock/ARTiledImageView) - [@dblock](https://github.com/dblock).
+* Extracted [NADotAnnotation](NAMapKit/NADotAnnotation.h) out of [NAAnnotation](NAMapKit/NAAnnotation.h), which is now a pure virtual class - [@dblock](https://github.com/dblock).
+* Fix: `NADotAnnotation` dots resize proportionally when map zoom level changes - [@dblock](https://github.com/dblock).
+* Exposed `NAMapView#doubleTapGesture` and `NAMapView#twoFingerTapGesture` - [@orta](https://github.com/orta).
 
 #### [3.0](https://github.com/neilang/NAMapKit/tree/v3.0) (3/15/2014)
 
-* [#16](https://github.com/neilang/NAMapKit/pull/16) - Extracted [NAPinAnnotationMapView](NAMapKit/NAPinAnnotationMapView.h) out of a, now mimimal, `NAMapView` - [@dblock](github.com/dblock).
-* [#18](https://github.com/neilang/NAMapKit/pull/18) - Added [NAMapViewDelegate](NAMapKit/NAMapViewDelegate.h) for easier handling of taps and zoom events - [@dblock](github.com/dblock).
-* [#19](https://github.com/neilang/NAMapKit/pull/19) - Added [NATiledImageMapView](NAMapKit/NATiledImageMapView.h) with support for deep-zoom tiled maps - [@dblock](github.com/dblock), [@orta](github.com/orta).
-* [#20](https://github.com/neilang/NAMapKit/pull/20) - Zoom now pans and rests at the point being tapped - [@orta](github.com/orta).
-* [#14](https://github.com/neilang/NAMapKit/pull/14) - Added tests and [Travis-CI](https://travis-ci.org/neilang/NAMapKit) - [@dblock](github.com/dblock).
+* [#16](https://github.com/neilang/NAMapKit/pull/16) - Extracted [NAPinAnnotationMapView](NAMapKit/NAPinAnnotationMapView.h) out of a, now mimimal, `NAMapView` - [@dblock](https://github.com/dblock).
+* [#18](https://github.com/neilang/NAMapKit/pull/18) - Added [NAMapViewDelegate](NAMapKit/NAMapViewDelegate.h) for easier handling of taps and zoom events - [@dblock](https://github.com/dblock).
+* [#19](https://github.com/neilang/NAMapKit/pull/19) - Added [NATiledImageMapView](NAMapKit/NATiledImageMapView.h) with support for deep-zoom tiled maps - [@dblock](https://github.com/dblock), [@orta](https://github.com/orta).
+* [#20](https://github.com/neilang/NAMapKit/pull/20) - Zoom now pans and rests at the point being tapped - [@orta](https://github.com/orta).
+* [#14](https://github.com/neilang/NAMapKit/pull/14) - Added tests and [Travis-CI](https://travis-ci.org/neilang/NAMapKit) - [@dblock](https://github.com/dblock).
 
 #### [2.1](https://github.com/neilang/NAMapKit/tree/v2.1)
 

--- a/Demo/Demo.xcworkspace/xcshareddata/Demo.xccheckout
+++ b/Demo/Demo.xcworkspace/xcshareddata/Demo.xccheckout
@@ -5,36 +5,36 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>5D0517DF-3DB0-4194-9E13-D3150DFB3E70</string>
+	<string>91DB7322-98D0-4C11-8B43-AC4544D5A61C</string>
 	<key>IDESourceControlProjectName</key>
 	<string>Demo</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>C8E2ACB0-618C-4AB4-89C9-8AA4D0C91775</key>
-		<string>ssh://github.com/neilang/NAMapKit.git</string>
+		<key>E1849B94-A142-4B49-93EB-CE798BC87886</key>
+		<string>ssh://github.com/dblock/NAMapKit.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>Demo/Demo.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>C8E2ACB0-618C-4AB4-89C9-8AA4D0C91775</key>
+		<key>E1849B94-A142-4B49-93EB-CE798BC87886</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/neilang/NAMapKit.git</string>
+	<string>ssh://github.com/dblock/NAMapKit.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>C8E2ACB0-618C-4AB4-89C9-8AA4D0C91775</string>
+	<string>E1849B94-A142-4B49-93EB-CE798BC87886</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>C8E2ACB0-618C-4AB4-89C9-8AA4D0C91775</string>
+			<string>E1849B94-A142-4B49-93EB-CE798BC87886</string>
 			<key>IDESourceControlWCCName</key>
-			<string>neilang</string>
+			<string>dblock</string>
 		</dict>
 	</array>
 </dict>

--- a/NAMapKit/NAAnnotation.h
+++ b/NAMapKit/NAAnnotation.h
@@ -40,6 +40,6 @@
 /// A delegate to invoke map-specific events.
 @property (nonatomic, weak) NSObject<NAMapViewDelegate> *mapViewDelegate;
 /// Map view to which the annotation currently belongs.
-@property (nonatomic, readonly) NAMapView *mapView;
+@property (nonatomic, readonly, weak) NAMapView *mapView;
 
 @end

--- a/NAMapKit/NAAnnotation.m
+++ b/NAMapKit/NAAnnotation.m
@@ -35,7 +35,6 @@ const CGFloat NAMapViewAnnotationDotOpacity = 0.5f;
     }
 
     [mapView addSubview:self.view];
-    [mapView addObserver:self forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
     _mapView = mapView;
 
     _mapViewDelegate = mapView.mapViewDelegate;
@@ -46,19 +45,16 @@ const CGFloat NAMapViewAnnotationDotOpacity = 0.5f;
 - (void)removeFromMapView
 {
     [self.view removeFromSuperview];
-    [self.mapView removeObserver:self forKeyPath:@"contentSize"];
     _mapView = nil;
     _view = nil;
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-	if ([keyPath isEqualToString:@"contentSize"]) {
-        [self updatePosition];
-	}
-}
-
-- (void)updatePosition {
-    if (! self.mapView) return;
+- (void)updatePosition
+{
+    if (!self.mapView) {
+        return;
+    }
+    
     CGPoint point = [self.mapView zoomRelativePoint:self.point];
     self.view.frame = (CGRect) {
         .origin = point,

--- a/NAMapKit/NADotAnnotation.m
+++ b/NAMapKit/NADotAnnotation.m
@@ -14,8 +14,12 @@ const CGFloat NAMapViewDotAnnotationDotOpacity = 0.5f;
 
 @implementation NADotAnnotation
 
-- (void)updatePosition{
-    if (! self.mapView) return;
+- (void)updatePosition
+{
+    if (!self.mapView) {
+        return;
+    }
+    
     CGFloat radius = (self.radius ?: NAMapViewDotAnnotationDotRadius) * self.mapView.zoomScale;
     CGPoint point = [self.mapView zoomRelativePoint:self.point];
     point.x -= radius;

--- a/NAMapKit/NAMapView.h
+++ b/NAMapKit/NAMapView.h
@@ -29,6 +29,8 @@
 - (void)centerOnPoint:(CGPoint)point animated:(BOOL)animate;
 /// Callback invoked to setup the map.
 - (void)setupMap;
+/// Recalculate position of all elements.
+- (void)updatePositions;
 
 /// Current map zoom level.
 @property (readonly, nonatomic, assign) CGFloat zoomLevel;

--- a/NAMapKit/NAPinAnnotation.m
+++ b/NAMapKit/NAPinAnnotation.m
@@ -12,12 +12,13 @@
 const CGFloat NAMapViewPinAnimationDuration = 0.5f;
 
 @interface NAPinAnnotation ()
-@property (nonatomic, readonly) NAPinAnnotationView *view;
+@property (nonatomic, readonly, weak) NAPinAnnotationView *view;
 @end
 
 @implementation NAPinAnnotation
 
-- (id)initWithPoint:(CGPoint)point{
+- (id)initWithPoint:(CGPoint)point
+{
     self = [super initWithPoint:point];
     if (self) {
         self.color = NAPinColorRed;
@@ -37,13 +38,13 @@ const CGFloat NAMapViewPinAnimationDuration = 0.5f;
 {
     [super addToMapView:mapView animated:animate];
 
-    if(animate){
+    if (animate) {
         self.view.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, 0.0f, -self.view.center.y);
     }
 
     [mapView addSubview:self.view];
 
-    if(animate){
+    if (animate) {
         self.view.animating = YES;
         [UIView animateWithDuration:NAMapViewPinAnimationDuration animations:^{
             self.view.transform = CGAffineTransformIdentity;

--- a/NAMapKit/NAPinAnnotationCallOutView.h
+++ b/NAMapKit/NAPinAnnotationCallOutView.h
@@ -18,6 +18,9 @@
 /// Create a new callout view on a map.
 - (id)initOnMapView:(NAMapView *)mapView;
 
+/// Recalculate position on map according to zoom level.
+- (void)updatePosition;
+
 /// Pin annotation.
 @property(readwrite, nonatomic, strong) NAPinAnnotation *annotation;
 

--- a/NAMapKit/NAPinAnnotationCallOutView.m
+++ b/NAMapKit/NAPinAnnotationCallOutView.m
@@ -38,7 +38,6 @@ static NSString *NAMapViewAnnotationCalloutImageBG = @"callout_bg.png";
 @property (nonatomic, assign) CGPoint      position;
 @property (nonatomic, weak)   NAMapView   *mapView;
 
-- (void)updatePosition;
 - (void)positionView:(UIView *)view posX:(float)x;
 - (void)positionView:(UIView *)view posX:(float)x width:(float)width;
 
@@ -187,12 +186,6 @@ static NSString *NAMapViewAnnotationCalloutImageBG = @"callout_bg.png";
 
     [self addSubview:self.titleLabel];
 
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-	if ([keyPath isEqualToString:@"contentSize"]) {
-        [self updatePosition];
-	}
 }
 
 #pragma - Private helpers

--- a/NAMapKit/NAPinAnnotationMapView.m
+++ b/NAMapKit/NAPinAnnotationMapView.m
@@ -12,11 +12,10 @@ const CGFloat NAMapViewAnnotationCalloutAnimationDuration = 0.1f;
 
 @interface NAPinAnnotationMapView()
 
-@property (nonatomic, strong) NAPinAnnotationCallOutView  *calloutView;
+@property (nonatomic, strong) NAPinAnnotationCallOutView *calloutView;
 
 - (IBAction)showCallOut:(id)sender;
 - (void)hideCallOut;
-
 @end
 
 @implementation NAPinAnnotationMapView
@@ -25,8 +24,7 @@ const CGFloat NAMapViewAnnotationCalloutAnimationDuration = 0.1f;
 {
     [super setupMap];
 
-    self.calloutView = [[NAPinAnnotationCallOutView alloc] initOnMapView:self];
-    [self addObserver:self.calloutView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
+    _calloutView = [[NAPinAnnotationCallOutView alloc] initOnMapView:self];
     [self addSubview:self.calloutView];
 }
 
@@ -71,8 +69,9 @@ const CGFloat NAMapViewAnnotationCalloutAnimationDuration = 0.1f;
     self.calloutView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.4f, 0.4f);
     self.calloutView.hidden = NO;
 
+    __weak typeof(self) weakSelf = self;
     [UIView animateWithDuration:animationDuration animations:^{
-        self.calloutView.transform = CGAffineTransformIdentity;
+        weakSelf.calloutView.transform = CGAffineTransformIdentity;
     }];
 }
 
@@ -88,10 +87,10 @@ const CGFloat NAMapViewAnnotationCalloutAnimationDuration = 0.1f;
 	[super touchesEnded:touches withEvent:event];
 }
 
-- (void)dealloc {
-    if(self.calloutView) {
-        [self removeObserver:self.calloutView forKeyPath:@"contentSize"];
-    }
+- (void)updatePositions
+{
+    [self.calloutView updatePosition];
+    [super updatePositions];
 }
 
 @end

--- a/NAMapKit/NAPinAnnotationView.h
+++ b/NAMapKit/NAPinAnnotationView.h
@@ -16,7 +16,7 @@
 @interface NAPinAnnotationView : UIButton
 
 /// Associated NAPinAnnotation.
-@property (readwrite, nonatomic, strong) NAPinAnnotation *annotation;
+@property (readwrite, nonatomic, weak) NAPinAnnotation *annotation;
 /// Animate the pin.
 @property (readwrite, nonatomic, assign) BOOL animating;
 


### PR DESCRIPTION
It's very real. Those two are holding each-other.  I had to move quite a bit of observer logic around to detangle things.

![leak](https://cloud.githubusercontent.com/assets/542335/2933750/0abd1c6e-d7c3-11e3-8837-8907239ea268.gif)

Closes #31.
