### PR TITLE
Updates travis' xcode to 7.2, re-adds tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: objective-c
 before_script:
-  - brew update
-  - brew uninstall xctool
-  - brew install xctool
   - export LANG=en_US.UTF-8
   - cd Demo ; pod install ; cd ..
 xcode_workspace: Demo/Demo.xcworkspace
 xcode_scheme: Demo
 xcode_sdk: iphonesimulator
-
+xctool_args: -destination "platform=iOS Simulator,name=iPhone 4s"
+osx_image: xcode7.2

--- a/Demo/Demo.xcworkspace/xcshareddata/Demo.xcscmblueprint
+++ b/Demo/Demo.xcworkspace/xcshareddata/Demo.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "DF84A17CEBC8A9F5FB371ADC46FB541D99429222",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "E1849B94-A142-4B49-93EB-CE798BC87886" : 0,
+    "DF84A17CEBC8A9F5FB371ADC46FB541D99429222" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "91DB7322-98D0-4C11-8B43-AC4544D5A61C",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "E1849B94-A142-4B49-93EB-CE798BC87886" : "dblock",
+    "DF84A17CEBC8A9F5FB371ADC46FB541D99429222" : "NAMapKit\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "Demo",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Demo\/Demo.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/neilang\/NAMapKit\/",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "DF84A17CEBC8A9F5FB371ADC46FB541D99429222"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "ssh:\/\/github.com\/dblock\/NAMapKit.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E1849B94-A142-4B49-93EB-CE798BC87886"
+    }
+  ]
+}

--- a/Demo/DemoTests/NAAnnotationDemoViewControllerTests.m
+++ b/Demo/DemoTests/NAAnnotationDemoViewControllerTests.m
@@ -13,7 +13,7 @@ SpecBegin(NAAnnotationDemoViewController)
 it(@"displays map with a pin", ^{
     NADotAnnotationDemoViewController *vc = [[NADotAnnotationDemoViewController alloc] init];
     expect(vc.view).willNot.beNil();
-//    expect(vc.view).will.haveValidSnapshotNamed(@"default");
+    expect(vc.view).will.haveValidSnapshotNamed(@"default");
 });
 
 SpecEnd

--- a/Demo/DemoTests/NAInteractiveDemoViewControllerTests.m
+++ b/Demo/DemoTests/NAInteractiveDemoViewControllerTests.m
@@ -17,27 +17,27 @@ beforeEach(^{
     expect(vc.view).willNot.beNil();
 });
 
-//it(@"doesn't display any pins", ^{
-//    expect(vc.view).will.haveValidSnapshotNamed(@"default");
-//});
+it(@"doesn't display any pins", ^{
+    expect(vc.view).will.haveValidSnapshotNamed(@"default");
+});
 
-//it(@"adds a pin", ^{
-//    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
-//    expect(vc.view).will.haveValidSnapshotNamed(@"add");
-//});
+it(@"adds a pin", ^{
+    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
+    expect(vc.view).will.haveValidSnapshotNamed(@"add");
+});
 
-//it(@"removes a pin", ^{
-//    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
-//    [vc addPinAt:CGPointMake(200, 300) withColor:NAPinColorGreen animated:NO];
-//    [vc removePinAt:0 animated:NO];
-//    expect(vc.view).will.haveValidSnapshotNamed(@"remove");
-//});
+it(@"removes a pin", ^{
+    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
+    [vc addPinAt:CGPointMake(200, 300) withColor:NAPinColorGreen animated:NO];
+    [vc removePinAt:0 animated:NO];
+    expect(vc.view).will.haveValidSnapshotNamed(@"remove");
+});
 
-//it(@"selects a pin", ^{
-//    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
-//    [vc addPinAt:CGPointMake(200, 300) withColor:NAPinColorGreen animated:NO];
-//    [vc selectPinAt:1 animated:NO];
-//    expect(vc.view).will.haveValidSnapshotNamed(@"select");
-//});
+it(@"selects a pin", ^{
+    [vc addPinAt:CGPointMake(100, 200) withColor:NAPinColorRed animated:NO];
+    [vc addPinAt:CGPointMake(200, 300) withColor:NAPinColorGreen animated:NO];
+    [vc selectPinAt:1 animated:NO];
+    expect(vc.view).will.haveValidSnapshotNamed(@"select");
+});
 
 SpecEnd

--- a/Demo/DemoTests/NALoadViaNIBDemoViewControllerTests.m
+++ b/Demo/DemoTests/NALoadViaNIBDemoViewControllerTests.m
@@ -13,7 +13,7 @@ SpecBegin(NALoadViaNIBDemoViewController)
 it(@"displays a menu", ^{
     NALoadViaNIBDemoViewController *vc = [[NALoadViaNIBDemoViewController alloc] init];
     expect(vc.view).willNot.beNil();
-//    expect(vc.view).will.haveValidSnapshotNamed(@"default");
+    expect(vc.view).will.haveValidSnapshotNamed(@"default");
 });
 
 SpecEnd

--- a/Demo/DemoTests/NAMasterViewControllerTests.m
+++ b/Demo/DemoTests/NAMasterViewControllerTests.m
@@ -13,7 +13,7 @@ SpecBegin(NAMasterViewController)
 it(@"displays the master menu", ^{
     NAMasterViewController *vc = [[NAMasterViewController alloc] initWithNibName:@"NAMasterViewController" bundle:nil];
     expect(vc.view).willNot.beNil();
-//    expect(vc.view).will.haveValidSnapshotNamed(@"default");
+    expect(vc.view).will.haveValidSnapshotNamed(@"default");
 });
 
 SpecEnd

--- a/Demo/DemoTests/NAPinAnnotationsDemoViewControllerTests.m
+++ b/Demo/DemoTests/NAPinAnnotationsDemoViewControllerTests.m
@@ -18,8 +18,8 @@ beforeEach(^{
     expect(vc.view).willNot.beNil();
 });
 
-//it(@"displays map with a pin", ^{
-//    expect(vc.view).will.haveValidSnapshotNamed(@"default");
-//});
+it(@"displays map with a pin", ^{
+    expect(vc.view).will.haveValidSnapshotNamed(@"default");
+});
 
 SpecEnd

--- a/Demo/DemoTests/NATiledImageMapViewControllerTests.m
+++ b/Demo/DemoTests/NATiledImageMapViewControllerTests.m
@@ -19,12 +19,12 @@ beforeEach(^{
     [window makeKeyAndVisible];
 });
 
-//it(@"displays map with a pin", ^AsyncBlock {
-//    dispatch_async(dispatch_get_main_queue(), ^{
-//        [NSThread sleepForTimeInterval:3.0];
-//        expect(vc.view).will.haveValidSnapshotNamed(@"default");
-//        done();
-//    });
-//});
+it(@"displays map with a pin", ^AsyncBlock {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [NSThread sleepForTimeInterval:3.0];
+        expect(vc.view).will.haveValidSnapshotNamed(@"default");
+        done();
+    });
+});
 
 SpecEnd


### PR DESCRIPTION
Didn't realise #46 basically removed _all_ tests, sorry about that - really shouldn't have merged. We rely on NAMapKit a lot, I don't feel good about having it without any tests.

Looks like the new snapshots were recording the new snapshots on a 9.0, but they were still being ran against 7.0. Apple will have made rendering changes between the two major versions. This fixes that.

This should fix #47 